### PR TITLE
Fix for submodel liveries.

### DIFF
--- a/lua/autorun/photon/cl_emv_livery.lua
+++ b/lua/autorun/photon/cl_emv_livery.lua
@@ -66,7 +66,7 @@ end
 Photon.AutoLivery.ApplyFallback = function( ent, id )
 	if tostring( ent.VehicleName ) != "nil" then
 		local fallbackMaterial = Photon.AutoLivery.FindFallback( ent.VehicleName, id )
-		if fallbackMaterial != "" then 
+		if fallbackMaterial != "" then
 			local applyIndex = ent:Photon_GetAutoSkinIndex()
 			if applyIndex then
 				ent:SetSubMaterial( applyIndex, fallbackMaterial )
@@ -99,6 +99,9 @@ Photon.AutoLivery.ApplyTexture = function( mat, ent, car, val, id )
 		UnitID = veh:Photon_GetUnitNumber(),
 		LiveryID = veh:Photon_GetLiveryID()
 	}
+	for _, prop in ipairs(EMVU.Helper.GetSubProps(veh)) do
+		prop:SetSubMaterial(applyIndex, "!" .. tostring(newLivery:GetName()))
+	end
 end
 
 Photon.AutoLivery.LoadLivery = function( car, id, val )

--- a/lua/autorun/photon/sh_emv_helper.lua
+++ b/lua/autorun/photon/sh_emv_helper.lua
@@ -568,3 +568,16 @@ function EMVU.Helper.GetBonePositionFromRE( car, lbEntity, posInput )
 	local boneWorldPos, boneWorldAng = lbEntity:GetBonePosition( boneIndex )
 	return boneWorldPos
 end
+
+--- Fetch the sub props used in multi-prop vehicles.
+-- @ent car Vehicle to fetch sub props for.
+-- @treturn table Array of subprops.
+function EMVU.Helper.GetSubProps(car)
+	local out = {}
+	for _, prop in ipairs(car:GetChildren()) do
+		if prop:GetClass() == "prop_dynamic_ornament" then
+			table.insert(out, prop)
+		end
+	end
+	return out
+end

--- a/lua/autorun/photon/sv_emv_meta.lua
+++ b/lua/autorun/photon/sv_emv_meta.lua
@@ -485,8 +485,13 @@ function EMVU:MakeEMV( ent, emv )
 			end
 		end
 		if submaterialIndex == false then return end
-		if index then self:SetSkin( index ) else self:SetSkin( 0 ) end
-		self:SetSubMaterial( submaterialIndex, tostring( mat ) )
+		if index then self:SetSkin(index) else self:SetSkin(0) end
+
+		mat = tostring(mat)
+		self:SetSubMaterial(submaterialIndex, mat)
+		for _, prop in ipairs(EMVU.Helper.GetSubProps(self)) do
+			prop:SetSubMaterial(submaterialIndex, mat)
+		end
 	end
 
 	function ent:ApplyPhotonSkin( skin, index, mat )
@@ -645,7 +650,7 @@ function EMVU:MakeEMV( ent, emv )
 	if istable( emv.Auto ) and emv.Auto[1] and istable( emv.Presets ) then
 		ent:ELS_PresetOption( 1 )
 	end
-	
+
 	ent:ELS_SirenOption( 1 )
 	ent:ELS_LightOption( 1 )
 	ent:ELS_IlluminateOption ( 1 )


### PR DESCRIPTION
Syncs submaterial changes for (auto)liveries to vehicle submodels (prop_ornements parents to the main car).