### PR TITLE
Hotfix: Express creator siren

### DIFF
--- a/lua/autorun/photon/cl_photon_toolmenu.lua
+++ b/lua/autorun/photon/cl_photon_toolmenu.lua
@@ -83,8 +83,8 @@ end
 local function createSirenOptions()
 	list.Set("PhotonSirenOptions", "None",  {photon_creator_siren = "0"})
 	local sirenTable = EMVU.GetSirenTable()
-	for _, siren in ipairs(sirenTable) do
-		list.Set("PhotonSirenOptions", siren.Category .. " - " .. siren.Name, {photon_creator_siren = tostring(i)})
+	for index, siren in ipairs(sirenTable) do
+		list.Set("PhotonSirenOptions", siren.Category .. " - " .. siren.Name, {photon_creator_siren = tostring(index)})
 	end
 end
 


### PR DESCRIPTION
When using the express creator, EMV.Siren will stay 0. This hotfix fixes it.

I blame Doctor Internet for all of this