### PR TITLE
Update Photon Menu on Dev Branch.

### DIFF
--- a/lua/autorun/photon/cl_photon_menu.lua
+++ b/lua/autorun/photon/cl_photon_menu.lua
@@ -1,15 +1,18 @@
 AddCSLuaFile()
 
-list.Set( "DesktopWindows", "PhotonMenu", {
+list.Set("DesktopWindows", "PhotonMenu", {
 	title = "Photon",
 	icon = "photon/ui/photon_menu.png",
 	init = function(icon, window)
 		OpenPhotonMenu()
 	end
-} )
+})
 
 function OpenPhotonMenu()
-	if PhotonWebPage then PhotonWebPage:Refresh() end
+	if PhotonWebPage then
+		PhotonWebPage:Refresh()
+	end
+
 	if not PhotonWebPage then
 		PhotonWebPage = vgui.Create("DHTML")
 		PhotonWebPage:SetVisible(false)
@@ -18,15 +21,19 @@ function OpenPhotonMenu()
 		PhotonWebPage:OpenURL("https://menu.photon.lighting/photon.html")
 		PhotonWebPage:SetAllowLua(true)
 	end
+
 	PhotonWebPage:SetVisible(true)
 	PhotonWebPage:MakePopup()
 end
+
 concommand.Add("photon_menu", OpenPhotonMenu)
 
 function ClosePhotonMenu()
-	if PhotonWebPage then PhotonWebPage:SetVisible(false) end
+	if PhotonWebPage then
+		PhotonWebPage:SetVisible(false)
+	end
 end
 
-net.Receive( "photon_menu", function()
+net.Receive("photon_menu", function()
 	OpenPhotonMenu()
 end)

--- a/lua/autorun/photon/cl_photon_menu.lua
+++ b/lua/autorun/photon/cl_photon_menu.lua
@@ -15,7 +15,7 @@ function OpenPhotonMenu()
 		PhotonWebPage:SetVisible(false)
 		PhotonWebPage:SetSize(ScrW() * .66, ScrH() * .66)
 		PhotonWebPage:Center()
-		PhotonWebPage:OpenURL("https://photon.lighting/menu/")
+		PhotonWebPage:OpenURL("https://photonle.github.io/menu/photon.html")
 		PhotonWebPage:SetAllowLua(true)
 	end
 	PhotonWebPage:SetVisible(true)

--- a/lua/autorun/photon/cl_photon_menu.lua
+++ b/lua/autorun/photon/cl_photon_menu.lua
@@ -15,7 +15,7 @@ function OpenPhotonMenu()
 		PhotonWebPage:SetVisible(false)
 		PhotonWebPage:SetSize(ScrW() * .66, ScrH() * .66)
 		PhotonWebPage:Center()
-		PhotonWebPage:OpenURL("https://photonle.github.io/menu/photon.html")
+		PhotonWebPage:OpenURL("https://menu.photon.lighting/photon.html")
 		PhotonWebPage:SetAllowLua(true)
 	end
 	PhotonWebPage:SetVisible(true)


### PR DESCRIPTION
This points the photon.lighting/menu at menu.photon.lighting (which is now on github pages, and uses a new method for generating the page).