### PR TITLE
fix lighting behind refract textures

### DIFF
--- a/lua/autorun/photon/cl_emv_meta.lua
+++ b/lua/autorun/photon/cl_emv_meta.lua
@@ -599,7 +599,7 @@ function EMVU:MakeEMV( emv, name )
 			if p == true then continue end
 			if not p.Model then continue end
 			local rendergroup = p.RenderGroup or RENDERGROUP_OPAQUE
-			local rendermode = p.RenderMode or RENDERMODE_TRANSALPHA
+			local rendermode = p.RenderMode or RENDERMODE_NONE
 			util.PrecacheModel( p.Model )
 			if not util.IsModelLoaded( p.Model ) then self:AlertPhotonMissingRequirements( p.Model ) end
 			local prop = ClientsideModel( p.Model, rendergroup )

--- a/lua/autorun/photon/cl_photon_eng.lua
+++ b/lua/autorun/photon/cl_photon_eng.lua
@@ -321,14 +321,14 @@ local bloomColor = nil
 
 function Photon.QuickDrawNoTable( srcOnly, drawSrc, camPos, camAng, srcSprite, srcT, srcR, srcB, srcL, worldPos, bloomScale, flareScale, widthScale, colSrc, colMed, colAmb, colBlm, colGlw, colRaw, colFlr, lightMod, cheap, viewFlare, multiEmit, SubmatID, SubmatMaterial, SubmatParent, debug_mode )
 
-	if drawSrc then
-		startCam( camPos, camAng, 1 )
-			setRenderLighting( 2 )
-			setMaterial( srcSprite )
-			drawQuad( srcT, srcR, srcB, srcL, colSrc )
-			setRenderLighting( 0 )
-		endCam()
-	end
+	-- if drawSrc then
+	-- 	startCam( camPos, camAng, 1 )
+	-- 		setRenderLighting( 2 )
+	-- 		setMaterial( srcSprite )
+	-- 		drawQuad( srcT, srcR, srcB, srcL, colSrc )
+	-- 		setRenderLighting( 0 )
+	-- 	endCam()
+	-- end
 
 	if SubmatID then
 		SubmatParent:SetSubMaterial(SubmatID, SubmatMaterial)
@@ -370,6 +370,19 @@ function Photon.QuickDrawNoTable( srcOnly, drawSrc, camPos, camAng, srcSprite, s
 				drawSprite( worldPos, 12 * widthScale, 12 * bloomScale, colMed )
 		end
 	end
+end
+--2,3,4,5,6,7,8,9,14
+function Photon.QuickDrawSrc( srcOnly, drawSrc, camPos, camAng, srcSprite, srcT, srcR, srcB, srcL, worldPos, bloomScale, flareScale, widthScale, colSrc, colMed, colAmb, colBlm, colGlw, colRaw, colFlr, lightMod, cheap, viewFlare, multiEmit, SubmatID, SubmatMaterial, SubmatParent, debug_mode )
+
+	if drawSrc then
+		startCam( camPos, camAng, 1 )
+			setRenderLighting( 2 )
+			setMaterial( srcSprite )
+			drawQuad( srcT, srcR, srcB, srcL, colSrc )
+			setRenderLighting( 0 )
+		endCam()
+	end
+
 end
 
 local drawW = ScrW() * .5
@@ -486,6 +499,7 @@ function Photon.RenderDynamicLight( pos, dir, incol, index )
 end
 
 local quickDrawNoTable = Photon.QuickDrawNoTable
+local quickDrawSrc = Photon.QuickDrawSrc
 local photonScreenEffects = Photon.DrawScreenEffects
 local cam3d = cam.Start3D
 local cam2d = cam.Start2D
@@ -498,7 +512,7 @@ hook.Add( "InitPostEntity", "Photon.DrawEffectsConvar", function()
 	dynlights_enabled = GetConVar( "photon_dynamic_lights" )
 end)
 
-function Photon:RenderQueue( effects )
+function Photon:RenderQueue( effects, drawSrc )
 	local eyePos = EyePos()
 	local eyeAng = EyeAngles()
 	local count = #photonRenderTable
@@ -506,7 +520,13 @@ function Photon:RenderQueue( effects )
 	if ( count > 0 ) then
 		local debug_mode = PHOTON_DEBUG
 		local renderFunction
-		if effects then renderFunction = photonScreenEffects else renderFunction = quickDrawNoTable end
+		if effects then renderFunction = photonScreenEffects else 
+			if not drawSrc then
+				renderFunction = quickDrawNoTable 
+			else
+				renderFunction = quickDrawSrc
+			end
+		end
 		for i=1, count do
 			if photonRenderTable[i] != nil then
 				local data = photonRenderTable[i]
@@ -519,10 +539,13 @@ function Photon:RenderQueue( effects )
 	-- Photon:ClearLightQueue()
 end
 hook.Add( "PreDrawEffects", "Photon.RenderQueue", function()
-	Photon:RenderQueue( false )
+	Photon:RenderQueue( false, false )
 	if draw_effects and draw_effects:GetBool() then
-		Photon:RenderQueue( true )
+		Photon:RenderQueue( true, false )
 	end
+end )
+hook.Add( "PostDrawOpaqueRenderables", "Photon.RenderQueue", function()
+		Photon:RenderQueue( false, true )
 end )
 local overlayX = math.Round(( ScrW() - ScrH() ) / 2)
 


### PR DESCRIPTION
- split src rendering and bloom rendering into 2 different hooks to make lights compatible with refract lenses

- change default rendermode of props to both fix transparency issues on interior props and most importantly prevent rendering issues with new src hook