### PR TITLE
Fix PI requiring EMV.

### DIFF
--- a/lua/autorun/photon/cl_emv_init.lua
+++ b/lua/autorun/photon/cl_emv_init.lua
@@ -62,7 +62,7 @@ local function DrawCarLights()
 	for _, ent in pairs(Photon:AllVehicles() ) do
 		if IsValid(ent) and ent:Photon() then
 			if not ent.Photon_RenderLights then
-				Photon:SetupCar(ent, ent:EMVName())
+				Photon:SetupCar(ent, ent:GetVehicleClass())
 			else
 				if should_render_reg:GetBool() then
 					ent:Photon_RenderLights(

--- a/lua/autorun/photon/sh_photon_vehicles.lua
+++ b/lua/autorun/photon/sh_photon_vehicles.lua
@@ -38,6 +38,17 @@ function Photon:EntityCreated( ent )
 					timer.Stop( timerId )
 					timer.Destroy( timerId )
 				end
+				if timer.RepsLeft( timerId ) == 0 and CLIENT then
+					local class = ent:GetVehicleClass()
+					local lst = list.Get("Vehicles")[class]
+					if lst and istable(lst) then
+						ent.VehicleTable = lst
+						Photon:SpawnedVehicle( ent )
+						EMVU:SpawnedVehicle( ent )
+						timer.Stop( timerId )
+						timer.Destroy( timerId )
+					end
+				end
 				if timer.RepsLeft( timerId ) == 0 and SERVER then
 					local default = Photon:RecoverVehicleTable( ent )
 					if default then

--- a/lua/autorun/photon/sv_photon_hooks.lua
+++ b/lua/autorun/photon/sv_photon_hooks.lua
@@ -1,7 +1,7 @@
 
 function Photon:RunningScan()
 	for k,v in pairs( self:AllVehicles() ) do
-		if IsValid( v ) and IsValid(v:GetDriver()) and v:GetDriver():IsPlayer() and v.IsEMV and v:IsEMV() then
+		if IsValid( v ) and IsValid(v:GetDriver()) and v:GetDriver():IsPlayer() and v:Photon() then
 			if v:IsBraking() then v:CAR_Braking(true) else v:CAR_Braking(false) end
 			if v:IsReversing() then v:CAR_Reversing(true) else v:CAR_Reversing(false) end
 		end
@@ -9,26 +9,29 @@ function Photon:RunningScan()
 end
 
 hook.Add("PlayerEnteredVehicle", "Photon.EnterVeh.SGM", function(ply, v)
-	if IsValid(v) and v.IsEMV and v:IsEMV() then
-		local hasELS = v:HasPhotonELS()
-		if hasELS and v.ELS.Blackout then
-			v:CAR_Running(false)
-		else
-			v:CAR_Running(true)
+	if IsValid(v) then
+		if v:Photon() then
+			v:CAR_Running(not v:CAR_IsBlackedOut())
 		end
-		if hasELS then v:ELS_ParkMode(false) end
+		if v:HasPhotonELS() then
+			v:ELS_ParkMode(false)
+		end
 	end
 end)
 
 hook.Add("PlayerLeaveVehicle", "Photon.LeaveVeh.SGM", function(ply, v)
-	if IsValid(v) and v.IsEMV and v:IsEMV() then
-		local hasELS = v:HasPhotonELS()
-		if hasELS then v:ELS_ParkMode(true) end
-		v:CAR_Running(false)
-		v:CAR_Braking(false)
-		v:CAR_Reversing(false)
-		if hasELS then
-			if v:ELS_Siren() then v:ELS_SirenOff() end
+	if IsValid(v) then
+		if v:Photon() then
+			v:CAR_Running(false)
+			v:CAR_Braking(false)
+			v:CAR_Reversing(false)
+		end
+
+		if v:HasPhotonELS() then
+			if v:ELS_Siren() then
+				v:ELS_SirenOff()
+			end
+
 			v:ELS_Horn(false)
 			v:ELS_ManualSiren(false)
 		end
@@ -37,7 +40,7 @@ end)
 
 hook.Add("KeyPress", "Photon.KeyPress.SGM", function(ply, key)
 	local v = ply:GetVehicle()
-	if IsValid(v) and v.IsEMV and v:IsEMV() then
+	if IsValid(v) and v:Photon() then
 		if v:IsBraking() then v:CAR_Braking(true) else v:CAR_Braking(false) end
 		if v:IsReversing() then v:CAR_Reversing(true) else v:CAR_Reversing(false) end
 	end
@@ -45,7 +48,7 @@ end)
 
 hook.Add("KeyRelease", "Photon.KeyRelease.SGM", function(ply, key)
 	local v = ply:GetVehicle()
-	if IsValid(v) and v.IsEMV and v:IsEMV() then
+	if IsValid(v) and v:Photon() then
 		if v:IsBraking() then v:CAR_Braking(true) else v:CAR_Braking(false) end
 		if v:IsReversing() then v:CAR_Reversing(true) else v:CAR_Reversing(false) end
 	end

--- a/lua/autorun/photon/sv_photon_meta.lua
+++ b/lua/autorun/photon/sv_photon_meta.lua
@@ -1,5 +1,17 @@
 
 function Photon:SetupCar( ent, index )
+	function ent:CAR_IsBlackedOut()
+		if self.IsEMV and self:IsEMV() then
+			// Lookup ELS Blackup State
+			local hasELS = v:HasPhotonELS()
+			if hasELS and v.ELS.Blackout then
+				return true
+			end
+		end
+
+		return false
+	end
+
 	// whether car headlights are on or off
 	function ent:CAR_Headlights( val )
 		if not IsValid( self ) then return false end


### PR DESCRIPTION
Fixes #177. Uses GetVehicleClass() instead of EMVName(), to avoid relying on EMVU for PI lighting.