### PR TITLE
Allow bodygroups to be in either format.

### DIFF
--- a/lua/autorun/photon/library/emv_auto.lua
+++ b/lua/autorun/photon/library/emv_auto.lua
@@ -9,6 +9,10 @@ function EMVU:AddAutoComponent(component, name, base)
 	component.Name = name
 	component.Base = component.Base or base or nil
 
+	if component.BodyGroups then
+		component.BodyGroups = EMVU.Helper.ResolveTable(component.BodyGroups)
+	end
+
 	local src = debug.getinfo(2, "S")
 	component.Source = src.short_src
 

--- a/lua/autorun/photon/sh_emv_helper.lua
+++ b/lua/autorun/photon/sh_emv_helper.lua
@@ -10,8 +10,31 @@ local istable = istable
 local pairs = pairs
 local tostring = tostring
 local math = math
+local insert = table.insert
 
 local printedErrors = {}
+
+--- Resolve a table, which is in either Map<idx, value>, (idx, value)[] or a mix, to be output in (idx, value)[] format, allowing for ipairs.
+-- @tab tab Input table.
+-- @rtab
+function EMVU.Helper.ResolveTable(tab)
+	if not istable(tab) then
+		PhotonWarning("Non table passed to ResolveTable")
+		PhotonWarning(debug.traceback())
+		return tab
+	end
+
+	local out = {}
+	for idx, value in pairs(tab) do
+		if istable(value) then
+			insert(out, value)
+		else
+			insert(out, {idx, value})
+		end
+	end
+
+	return out
+end
 
 function EMVU.Helper.GetAlertSequence( name, vehicle )
 	local resultTable = {}

--- a/lua/autorun/photon/sh_emv_vehicles.lua
+++ b/lua/autorun/photon/sh_emv_vehicles.lua
@@ -322,7 +322,12 @@ function EMVU:OverwriteIndex(name, data)
 	end
 
 	if istable(data.Auto) then
-		PrintTable(data.Auto)
+		for _, auto in pairs(data.Auto) do
+			if auto.BodyGroups then
+				auto.BodyGroups = EMVU.Helper.ResolveTable(auto.BodyGroups)
+			end
+		end
+
 		EMVU.AutoIndex[name] = data.Auto
 		EMVU:CalculateAuto(name, data.Auto, data.AutoInsert)
 	end

--- a/lua/autorun/photon/sh_emv_vehicles.lua
+++ b/lua/autorun/photon/sh_emv_vehicles.lua
@@ -275,7 +275,12 @@ function EMVU:OverwriteIndex(name, data)
 
 	if istable(data.Props) then
 		EMVU.Props[name] = data.Props
+
 		for _, prop in pairs(data.Props) do
+			if prop.BodyGroups then
+				prop.BodyGroups = EMVU.Helper.ResolveTable(prop.BodyGroups)
+			end
+
 			util.PrecacheModel(prop.Model)
 		end
 	end
@@ -299,10 +304,25 @@ function EMVU:OverwriteIndex(name, data)
 	end
 
 	if istable(data.AutoInsert) then
+		for _, auto in pairs(data.AutoInsert) do
+			if auto.BodyGroups then
+				auto.BodyGroups = EMVU.Helper.ResolveTable(auto.BodyGroups)
+			end
+
+			if auto.Variants then
+				for _, variant in ipairs(auto.Variants) do
+					if variant.BodyGroups then
+						variant.BodyGroups = EMVU.Helper.ResolveTable(variant.BodyGroups)
+					end
+				end
+			end
+		end
+
 		EMVU.AutoInsert[name] = data.AutoInsert
 	end
 
 	if istable(data.Auto) then
+		PrintTable(data.Auto)
 		EMVU.AutoIndex[name] = data.Auto
 		EMVU:CalculateAuto(name, data.Auto, data.AutoInsert)
 	end


### PR DESCRIPTION
Allows for bodygroups to be in
```
{bgId, bgVal}
```
or 
```
[bgId] = bgVal
```
formats.

Since we know anything which has been resolved must be a sequential table, we can also change any bodygroup manipulators to use ipairs (minor optimisation).